### PR TITLE
Adding OrionChat to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you want to add your app, feel free to open a pull request to add your app to
 - L-GPT | [demo](https://le-ai.app/) | [source](https://github.com/Peek-A-Booo/L-GPT)
 - LobeChat | [demo](https://lobechat.com/) | [source](https://github.com/lobehub/lobe-chat)
 - MyChatGPT | [demo](https://my-chat-gpt-lake.vercel.app/) | [source](https://github.com/Loeffeldude/my-chat-gpt)
+- OrionChat | [demo](https://eliaspereirah.github.io/OrionChat) | [source](https://github.com/EliasPereirah/OrionChat)
 - PatrikZero's ChatGPT UI | [demo](https://chat.patrikzudel.me/) | [source](https://github.com/patrikzudel/PatrikZeros-ChatGPT-API-UI)
   - Fork: SmoothGPT | [demo](https://smoothgpt.app) | [source](https://github.com/agambon/SmoothGPT)
 - SlickGPT | [demo](https://slickgpt.vercel.app) | [source](https://github.com/ShipBit/slickgpt)


### PR DESCRIPTION
If you are adding a new app to the list, please check the checkboxes to ensure you have done the following:
- [x] I have put the app in alphabetical order in the appropriate section of the page

This interface supports not only OpenAI, but also several other providers such as Google Gemini, Anthropic's Claude, Groq, SambaNova, and others.

GitHub project: https://github.com/EliasPereirah/OrionChat
Demo: https://eliaspereirah.github.io/OrionChat/